### PR TITLE
Add multithreaded scientific algorithms

### DIFF
--- a/src/main/java/com/unillanos/scientificcalculations/application/service/MatrixMultiplicationService.java
+++ b/src/main/java/com/unillanos/scientificcalculations/application/service/MatrixMultiplicationService.java
@@ -1,0 +1,7 @@
+package com.unillanos.scientificcalculations.application.service;
+
+import java.util.List;
+
+public interface MatrixMultiplicationService {
+    List<List<Double>> multiply(List<List<Double>> a, List<List<Double>> b, int threads);
+}

--- a/src/main/java/com/unillanos/scientificcalculations/application/service/MatrixMultiplicationServiceImpl.java
+++ b/src/main/java/com/unillanos/scientificcalculations/application/service/MatrixMultiplicationServiceImpl.java
@@ -1,0 +1,61 @@
+package com.unillanos.scientificcalculations.application.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+@Service
+public class MatrixMultiplicationServiceImpl implements MatrixMultiplicationService {
+
+    @Override
+    public List<List<Double>> multiply(List<List<Double>> a, List<List<Double>> b, int threads) {
+        int rowsA = a.size();
+        int colsA = a.get(0).size();
+        int colsB = b.get(0).size();
+
+        List<List<Double>> result = new ArrayList<>(rowsA);
+        for (int i = 0; i < rowsA; i++) {
+            List<Double> row = new ArrayList<>(colsB);
+            for (int j = 0; j < colsB; j++) {
+                row.add(0.0);
+            }
+            result.add(row);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        List<Future<Void>> futures = new ArrayList<>();
+
+        for (int i = 0; i < rowsA; i++) {
+            final int row = i;
+            futures.add(executor.submit(new Callable<>() {
+                @Override
+                public Void call() {
+                    for (int j = 0; j < colsB; j++) {
+                        double sum = 0.0;
+                        for (int k = 0; k < colsA; k++) {
+                            sum += a.get(row).get(k) * b.get(k).get(j);
+                        }
+                        result.get(row).set(j, sum);
+                    }
+                    return null;
+                }
+            }));
+        }
+
+        for (Future<Void> f : futures) {
+            try {
+                f.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        executor.shutdown();
+        return result;
+    }
+}

--- a/src/main/java/com/unillanos/scientificcalculations/application/service/MonteCarloPiService.java
+++ b/src/main/java/com/unillanos/scientificcalculations/application/service/MonteCarloPiService.java
@@ -1,0 +1,5 @@
+package com.unillanos.scientificcalculations.application.service;
+
+public interface MonteCarloPiService {
+    double calculatePi(long iterations, int threads);
+}

--- a/src/main/java/com/unillanos/scientificcalculations/application/service/MonteCarloPiServiceImpl.java
+++ b/src/main/java/com/unillanos/scientificcalculations/application/service/MonteCarloPiServiceImpl.java
@@ -1,0 +1,51 @@
+package com.unillanos.scientificcalculations.application.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class MonteCarloPiServiceImpl implements MonteCarloPiService {
+    @Override
+    public double calculatePi(long iterations, int threads) {
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        List<Future<Long>> futures = new ArrayList<>();
+        long iterationsPerThread = iterations / threads;
+
+        for (int i = 0; i < threads; i++) {
+            futures.add(executor.submit(new Callable<>() {
+                @Override
+                public Long call() {
+                    long inside = 0;
+                    ThreadLocalRandom random = ThreadLocalRandom.current();
+                    for (long j = 0; j < iterationsPerThread; j++) {
+                        double x = random.nextDouble();
+                        double y = random.nextDouble();
+                        if (x * x + y * y <= 1.0) {
+                            inside++;
+                        }
+                    }
+                    return inside;
+                }
+            }));
+        }
+
+        long insideTotal = 0;
+        for (Future<Long> f : futures) {
+            try {
+                insideTotal += f.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        executor.shutdown();
+        return 4.0 * insideTotal / iterations;
+    }
+}

--- a/src/main/java/com/unillanos/scientificcalculations/domain/dto/MatrixMultiplicationRequest.java
+++ b/src/main/java/com/unillanos/scientificcalculations/domain/dto/MatrixMultiplicationRequest.java
@@ -1,0 +1,5 @@
+package com.unillanos.scientificcalculations.domain.dto;
+
+import java.util.List;
+
+public record MatrixMultiplicationRequest(List<List<Double>> a, List<List<Double>> b, int threads) {}

--- a/src/main/java/com/unillanos/scientificcalculations/domain/dto/MatrixMultiplicationResponse.java
+++ b/src/main/java/com/unillanos/scientificcalculations/domain/dto/MatrixMultiplicationResponse.java
@@ -1,0 +1,5 @@
+package com.unillanos.scientificcalculations.domain.dto;
+
+import java.util.List;
+
+public record MatrixMultiplicationResponse(List<List<Double>> result) {}

--- a/src/main/java/com/unillanos/scientificcalculations/domain/dto/MonteCarloPiResponse.java
+++ b/src/main/java/com/unillanos/scientificcalculations/domain/dto/MonteCarloPiResponse.java
@@ -1,0 +1,3 @@
+package com.unillanos.scientificcalculations.domain.dto;
+
+public record MonteCarloPiResponse(double piEstimate) {}

--- a/src/main/java/com/unillanos/scientificcalculations/presentation/controller/AlgorithmsController.java
+++ b/src/main/java/com/unillanos/scientificcalculations/presentation/controller/AlgorithmsController.java
@@ -1,0 +1,36 @@
+package com.unillanos.scientificcalculations.presentation.controller;
+
+import com.unillanos.scientificcalculations.application.service.MatrixMultiplicationService;
+import com.unillanos.scientificcalculations.application.service.MonteCarloPiService;
+import com.unillanos.scientificcalculations.domain.dto.MatrixMultiplicationRequest;
+import com.unillanos.scientificcalculations.domain.dto.MatrixMultiplicationResponse;
+import com.unillanos.scientificcalculations.domain.dto.MonteCarloPiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/algorithms")
+public class AlgorithmsController {
+
+    private final MatrixMultiplicationService matrixService;
+    private final MonteCarloPiService piService;
+
+    public AlgorithmsController(MatrixMultiplicationService matrixService, MonteCarloPiService piService) {
+        this.matrixService = matrixService;
+        this.piService = piService;
+    }
+
+    @PostMapping("/matrix")
+    public ResponseEntity<MatrixMultiplicationResponse> multiply(@RequestBody MatrixMultiplicationRequest request) {
+        List<List<Double>> result = matrixService.multiply(request.a(), request.b(), request.threads());
+        return ResponseEntity.ok(new MatrixMultiplicationResponse(result));
+    }
+
+    @GetMapping("/pi")
+    public ResponseEntity<MonteCarloPiResponse> calculatePi(@RequestParam long iterations, @RequestParam int threads) {
+        double pi = piService.calculatePi(iterations, threads);
+        return ResponseEntity.ok(new MonteCarloPiResponse(pi));
+    }
+}

--- a/src/test/java/com/unillanos/scientificcalculations/service/MatrixMultiplicationServiceTests.java
+++ b/src/test/java/com/unillanos/scientificcalculations/service/MatrixMultiplicationServiceTests.java
@@ -1,0 +1,32 @@
+package com.unillanos.scientificcalculations.service;
+
+import com.unillanos.scientificcalculations.application.service.MatrixMultiplicationService;
+import com.unillanos.scientificcalculations.application.service.MatrixMultiplicationServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MatrixMultiplicationServiceTests {
+
+    private final MatrixMultiplicationService service = new MatrixMultiplicationServiceImpl();
+
+    @Test
+    void multiply2x2Matrices() {
+        List<List<Double>> a = Arrays.asList(
+                Arrays.asList(1.0, 2.0),
+                Arrays.asList(3.0, 4.0)
+        );
+        List<List<Double>> b = Arrays.asList(
+                Arrays.asList(5.0, 6.0),
+                Arrays.asList(7.0, 8.0)
+        );
+        List<List<Double>> result = service.multiply(a, b, 2);
+        assertEquals(19.0, result.get(0).get(0));
+        assertEquals(22.0, result.get(0).get(1));
+        assertEquals(43.0, result.get(1).get(0));
+        assertEquals(50.0, result.get(1).get(1));
+    }
+}

--- a/src/test/java/com/unillanos/scientificcalculations/service/MonteCarloPiServiceTests.java
+++ b/src/test/java/com/unillanos/scientificcalculations/service/MonteCarloPiServiceTests.java
@@ -1,0 +1,18 @@
+package com.unillanos.scientificcalculations.service;
+
+import com.unillanos.scientificcalculations.application.service.MonteCarloPiService;
+import com.unillanos.scientificcalculations.application.service.MonteCarloPiServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MonteCarloPiServiceTests {
+
+    private final MonteCarloPiService service = new MonteCarloPiServiceImpl();
+
+    @Test
+    void calculatePiApproximation() {
+        double pi = service.calculatePi(10000, 4);
+        assertTrue(pi > 3.0 && pi < 3.3);
+    }
+}


### PR DESCRIPTION
## Summary
- add MatrixMultiplicationService and MonteCarloPiService with multi-threaded implementations
- expose new AlgorithmsController endpoints
- create DTOs for requests and responses
- include basic unit tests for the algorithm services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d84da1ac083269985c155a90db11a